### PR TITLE
pugLinter integration

### DIFF
--- a/.pug-lintrc
+++ b/.pug-lintrc
@@ -1,0 +1,20 @@
+{
+    "disallowAttributeTemplateString": true,
+    "disallowBlockExpansion": true,
+    "disallowClassAttributeWithStaticValue": true,
+    "disallowClassLiteralsBeforeIdLiterals": true,
+    "disallowDuplicateAttributes": true,
+    "disallowLegacyMixinCall": true,
+    "disallowMultipleLineBreaks": true,
+    "disallowSpacesInsideAttributeBrackets": true,
+    "disallowTemplateString": true,
+    "requireClassLiteralsBeforeAttributes": true,
+    "requireIdLiteralsBeforeAttributes": true,
+    "requireLowerCaseAttributes": true,
+    "requireLowerCaseTags": true,
+    "validateAttributeQuoteMarks": "'",
+    "validateAttributeSeparator": ", ",
+    "validateDivTags": true,
+    "validateIndentation": "\t",
+    "disallowTrailingSpaces": true
+}

--- a/app/pug/layout.pug
+++ b/app/pug/layout.pug
@@ -2,27 +2,27 @@ doctype html
 
 html(lang='en')
 
-  head
+	head
 
-    meta(charset='UTF-8')
-    meta(http-equiv='x-ua-compatible', content='ie=edge')
-    meta(name='viewport', content='width=device-width, initial-scale=1.0, minimum-scale=1.0, user-scalable=no')
-    title='Horizon Boilerplate'
-    meta(name='description', content='Front-End Boilerplate is a starter kit that uses Gulp 4, Express.js, Webpack/Babel/ES6, SASS, PUG and foundation-sites framework')
-    link(rel='icon', type='image/png', href='images/favicon.png')
-    link(rel='stylesheet', href='./styles/app.css')
+		meta(charset='UTF-8')
+		meta(http-equiv='x-ua-compatible', content='ie=edge')
+		meta(name='viewport', content='width=device-width, initial-scale=1.0, minimum-scale=1.0, user-scalable=no')
+		title='Horizon Boilerplate'
+		meta(name='description', content='Front-End Boilerplate is a starter kit that uses Gulp 4, Express.js, Webpack/Babel/ES6, SASS, PUG and foundation-sites framework')
+		link(rel='icon', type='image/png', href='images/favicon.png')
+		link(rel='stylesheet', href='./styles/app.css')
 
-  body
+	body
 
-    block content
+		block content
 
-    script(src='https://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js')
+		script(src='https://ajax.googleapis.com/ajax/libs/webfont/1.5.18/webfont.js')
 
-    script.
-      WebFont.load({
-        google: {
-          families: ['Open Sans:300,400']
-        }
-      });
+		script.
+			WebFont.load({
+				google: {
+					families: ['Open Sans:300,400']
+				}
+			});
 
-    script(src='./scripts/app.js', async)
+		script(src='./scripts/app.js', async)

--- a/app/pug/pages/index.pug
+++ b/app/pug/pages/index.pug
@@ -2,4 +2,4 @@ extends ../layout
 
 block content
 
-   h1 Hello World!
+	h1 Hello World!

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -32,6 +32,7 @@ import reporter from 'postcss-reporter';
 import syntax_scss from 'postcss-scss';
 import stylelint from 'stylelint';
 import moment from 'moment';
+import pugLinter from 'gulp-pug-linter';
 
 /*
   Paths
@@ -78,6 +79,18 @@ export function onError(err) {
     console.log(err);
     this.emit('end');
 }
+
+/*
+  PUG Lint
+*/
+const nbErros = function (errors) {
+    if (errors.length) { console.error(errors.length) }
+}
+export const pugLint = () =>
+    gulp
+        .src(['app/pug/**/*.pug'])
+        .pipe(pugLinter())
+        .pipe(pugLinter.reporter())
 
 /*
   convert SASS files to CSS

--- a/package-lock.json
+++ b/package-lock.json
@@ -3104,6 +3104,12 @@
             "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
             "dev": true
         },
+        "css-selector-parser": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/css-selector-parser/-/css-selector-parser-1.3.0.tgz",
+            "integrity": "sha1-XxrUPi2O77/cME/NOaUhZklD4+s=",
+            "dev": true
+        },
         "csso": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
@@ -4686,6 +4692,12 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
             "integrity": "sha1-Z101iyyjiS15Whq0cjL4tuLg3eQ=",
+            "dev": true
+        },
+        "find-line-column": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/find-line-column/-/find-line-column-0.5.2.tgz",
+            "integrity": "sha1-2wAjj/hoVRoYLnShA0FtKVqYyMo=",
             "dev": true
         },
         "find-parent-dir": {
@@ -7107,6 +7119,18 @@
                 "plugin-error": "^1.0.1",
                 "pug": "^2.0.3",
                 "replace-ext": "^1.0.0",
+                "through2": "^2.0.3"
+            }
+        },
+        "gulp-pug-linter": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/gulp-pug-linter/-/gulp-pug-linter-0.6.0.tgz",
+            "integrity": "sha512-xil8keLaE8BIIfZBw2Ivburi+Rtol4B5BTTfH/HeBEuhOQmVsKOwm27eshZ3hxHIDyQ0ODmFgcT9F9xcFxrk1A==",
+            "dev": true,
+            "requires": {
+                "fancy-log": "^1.3.2",
+                "plugin-error": "^1.0.1",
+                "pug-lint": "^2.5.0",
                 "through2": "^2.0.3"
             }
         },
@@ -13068,6 +13092,46 @@
             "requires": {
                 "pug-error": "^1.3.2",
                 "pug-walk": "^1.1.7"
+            }
+        },
+        "pug-lint": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/pug-lint/-/pug-lint-2.5.0.tgz",
+            "integrity": "sha1-RBnuMBrspF9UBhsOykqaRx86qak=",
+            "dev": true,
+            "requires": {
+                "acorn": "^4.0.1",
+                "commander": "^2.9.0",
+                "css-selector-parser": "^1.1.0",
+                "find-line-column": "^0.5.2",
+                "glob": "^7.0.3",
+                "minimatch": "^3.0.3",
+                "path-is-absolute": "^1.0.0",
+                "pug-attrs": "^2.0.1",
+                "pug-error": "^1.3.0",
+                "pug-lexer": "^2.0.1",
+                "resolve": "^1.1.7",
+                "strip-json-comments": "^2.0.1",
+                "void-elements": "^2.0.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "4.0.13",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+                    "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+                    "dev": true
+                },
+                "pug-lexer": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-2.3.2.tgz",
+                    "integrity": "sha1-aLGdlupdwOSoYUiwHLlmwXgVphQ=",
+                    "dev": true,
+                    "requires": {
+                        "character-parser": "^2.1.1",
+                        "is-expression": "^3.0.0",
+                        "pug-error": "^1.3.2"
+                    }
+                }
             }
         },
         "pug-load": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "gulp-plumber": "^1.2.0",
         "gulp-postcss": "^7.0.1",
         "gulp-pug": "^4.0.1",
+        "gulp-pug-linter": "^0.6.0",
         "gulp-rename": "^1.4.0",
         "gulp-replace": "^1.0.0",
         "gulp-sass": "^4.0.1",


### PR DESCRIPTION
A no-frills wrapper for the pug-lint CLI. It expects the same configuration files as does the CLI tool. This means that whether you prefer linting from .pug-lintrc, .pug-lint.json, directly from package.json ("pugLintConfig": ...), or even the legacy .jade files, this plugin is going to work for you right out of the box. In addition, it can be set to fail once it encounters lint errors. That's important if you care about making the Continuous Integration (CI) builds to fail on error.